### PR TITLE
Add JavaDoc Comments for API Manager Classes to Improve Documentation

### DIFF
--- a/src/main/java/org/codelibs/fess/plugin/webapp/api/classic/ClassicJsonApiManager.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/api/classic/ClassicJsonApiManager.java
@@ -40,12 +40,35 @@ import org.lastaflute.web.util.LaResponseUtil;
 
 import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * Abstract base class for JSON API managers in the classic search API plugin.
+ * Provides JSON response formatting, JSONP support, error handling, and JSON escaping utilities.
+ * Extends BaseApiManager to handle JSON-formatted web API requests.
+ */
 public abstract class ClassicJsonApiManager extends BaseApiManager {
+
+    /**
+     * Default constructor for ClassicJsonApiManager.
+     */
+    public ClassicJsonApiManager() {
+        super();
+    }
 
     private static final Logger logger = LogManager.getLogger(ClassicJsonApiManager.class);
 
+    /**
+     * The MIME type for JSON responses.
+     */
     protected String mimeType = "application/json";
 
+    /**
+     * Writes a JSON response with the specified status, body, and exception.
+     * Handles error formatting and authentication exceptions appropriately.
+     *
+     * @param status the HTTP status code
+     * @param body the response body content
+     * @param t the exception that occurred, or null if no exception
+     */
     protected void writeJsonResponse(final int status, final String body, final Throwable t) {
         if (t == null) {
             writeJsonResponse(status, body, (String) null);
@@ -87,6 +110,13 @@ public abstract class ClassicJsonApiManager extends BaseApiManager {
         writeJsonResponse(status, body, message);
     }
 
+    /**
+     * Writes a JSON response with the specified status, body, and error message.
+     *
+     * @param status the HTTP status code
+     * @param body the response body content
+     * @param errMsg the error message to include in the response
+     */
     protected void writeJsonResponse(final int status, final String body, final String errMsg) {
         String content = null;
         if (status == 0) {
@@ -99,6 +129,13 @@ public abstract class ClassicJsonApiManager extends BaseApiManager {
         writeJsonResponse(status, content);
     }
 
+    /**
+     * Writes a JSON response with the specified status and body.
+     * Handles JSONP callback wrapping if enabled and callback parameter is provided.
+     *
+     * @param status the HTTP status code
+     * @param body the response body content
+     */
     protected void writeJsonResponse(final int status, final String body) {
         final String callback = LaRequestUtil.getOptionalRequest().map(req -> req.getParameter("callback")).orElse(null);
         final boolean isJsonp = ComponentUtil.getFessConfig().isApiJsonpEnabled() && StringUtil.isNotBlank(callback);
@@ -127,10 +164,24 @@ public abstract class ClassicJsonApiManager extends BaseApiManager {
 
     }
 
+    /**
+     * Escapes a JSONP callback name by removing potentially dangerous characters.
+     * Only allows alphanumeric characters, underscore, dollar sign, and dot.
+     *
+     * @param callbackName the callback name to escape
+     * @return the escaped callback name prefixed with /**\/
+     */
     protected String escapeCallbackName(final String callbackName) {
         return "/**/" + callbackName.replaceAll("[^0-9a-zA-Z_\\$\\.]", StringUtil.EMPTY);
     }
 
+    /**
+     * Escapes an object for safe inclusion in JSON output.
+     * Handles various data types including strings, arrays, lists, maps, numbers, booleans, and dates.
+     *
+     * @param obj the object to escape
+     * @return the JSON-escaped string representation of the object
+     */
     protected String escapeJson(final Object obj) {
         if (obj == null) {
             return "null";
@@ -186,6 +237,11 @@ public abstract class ClassicJsonApiManager extends BaseApiManager {
         return buf.toString();
     }
 
+    /**
+     * Sets the MIME type for responses.
+     *
+     * @param mimeType the MIME type to set
+     */
     public void setMimeType(final String mimeType) {
         this.mimeType = mimeType;
     }

--- a/src/main/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManager.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManager.java
@@ -60,14 +60,26 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * JSON API manager that handles search requests at the /json path prefix.
+ * Processes different request types including search, label, popular words, favorites, ping, and scroll.
+ * Extends ClassicJsonApiManager to provide JSON-formatted search API functionality.
+ */
 public class JsonApiManager extends ClassicJsonApiManager {
 
     private static final Logger logger = LogManager.getLogger(JsonApiManager.class);
 
+    /**
+     * Constructs a JsonApiManager with "/json" path prefix.
+     */
     public JsonApiManager() {
         setPathPrefix("/json");
     }
 
+    /**
+     * Registers this API manager with the WebApiManagerFactory.
+     * Called after construction to make this manager available for request processing.
+     */
     @PostConstruct
     public void register() {
         if (logger.isInfoEnabled()) {
@@ -125,6 +137,14 @@ public class JsonApiManager extends ClassicJsonApiManager {
         }
     }
 
+    /**
+     * Processes scroll search requests that return search results in NDJSON format.
+     * Allows streaming of large result sets without loading all results into memory.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processScrollSearchRequest(final HttpServletRequest request, final HttpServletResponse response,
             final FilterChain chain) {
         final SearchHelper searchHelper = ComponentUtil.getSearchHelper();
@@ -185,6 +205,13 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
     }
 
+    /**
+     * Processes ping requests to check the health status of the search engine.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processPingRequest(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) {
         final SearchEngineClient searchEngineClient = ComponentUtil.getSearchEngineClient();
         int status;
@@ -203,6 +230,14 @@ public class JsonApiManager extends ClassicJsonApiManager {
         }
     }
 
+    /**
+     * Processes search requests and returns search results in JSON format.
+     * Handles query processing, result formatting, faceting, and related content.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processSearchRequest(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) {
         final SearchHelper searchHelper = ComponentUtil.getSearchHelper();
         final FessConfig fessConfig = ComponentUtil.getFessConfig();
@@ -381,6 +416,12 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
     }
 
+    /**
+     * Creates a detailed error message from an exception, including nested causes.
+     *
+     * @param t the throwable to create a message for
+     * @return a detailed error message string
+     */
     protected String detailedMessage(final Throwable t) {
         if (t == null) {
             return "Unknown";
@@ -406,6 +447,13 @@ public class JsonApiManager extends ClassicJsonApiManager {
         return sb.toString();
     }
 
+    /**
+     * Processes label requests to retrieve available search labels.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processLabelRequest(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) {
         final LabelTypeHelper labelTypeHelper = ComponentUtil.getLabelTypeHelper();
 
@@ -447,6 +495,13 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
     }
 
+    /**
+     * Processes popular word requests to retrieve popular search terms.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processPopularWordRequest(final HttpServletRequest request, final HttpServletResponse response,
             final FilterChain chain) {
         if (!ComponentUtil.getFessConfig().isWebApiPopularWord()) {
@@ -503,6 +558,13 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
     }
 
+    /**
+     * Processes favorite requests to add documents to user favorites.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processFavoriteRequest(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) {
         if (!ComponentUtil.getFessConfig().isUserFavorite()) {
             writeJsonResponse(9, null, "Unsupported operation.");
@@ -589,6 +651,13 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
     }
 
+    /**
+     * Processes favorites requests to retrieve user's favorite documents.
+     *
+     * @param request the HTTP servlet request
+     * @param response the HTTP servlet response
+     * @param chain the filter chain
+     */
     protected void processFavoritesRequest(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain) {
         if (!ComponentUtil.getFessConfig().isUserFavorite()) {
             writeJsonResponse(9, null, "Unsupported operation.");
@@ -668,6 +737,10 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
     }
 
+    /**
+     * Request parameter wrapper for JSON API requests.
+     * Extracts and validates parameters from HTTP requests for search operations.
+     */
     protected static class JsonRequestParams extends SearchRequestParams {
 
         private final HttpServletRequest request;
@@ -680,6 +753,12 @@ public class JsonApiManager extends ClassicJsonApiManager {
 
         private int offset = -1;
 
+        /**
+         * Constructs JsonRequestParams from HTTP request and Fess configuration.
+         *
+         * @param request the HTTP servlet request
+         * @param fessConfig the Fess configuration
+         */
         protected JsonRequestParams(final HttpServletRequest request, final FessConfig fessConfig) {
             this.request = request;
             this.fessConfig = fessConfig;

--- a/src/main/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManager.java
+++ b/src/main/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManager.java
@@ -48,13 +48,25 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * Suggest API manager that handles search suggestions at the /suggest path prefix.
+ * Uses Fess suggest functionality to provide search term suggestions based on user input.
+ * Extends ClassicJsonApiManager to provide JSON-formatted suggestion responses.
+ */
 public class SuggestApiManager extends ClassicJsonApiManager {
     private static final Logger logger = LogManager.getLogger(SuggestApiManager.class);
 
+    /**
+     * Constructs a SuggestApiManager with "/suggest" path prefix.
+     */
     public SuggestApiManager() {
         setPathPrefix("/suggest");
     }
 
+    /**
+     * Registers this API manager with the WebApiManagerFactory.
+     * Called after construction to make this manager available for request processing.
+     */
     @PostConstruct
     public void register() {
         if (logger.isInfoEnabled()) {
@@ -162,6 +174,10 @@ public class SuggestApiManager extends ClassicJsonApiManager {
         writeJsonResponse(status, buf.toString(), errMsg);
     }
 
+    /**
+     * Request parameter wrapper for suggest API requests.
+     * Extracts and validates parameters from HTTP requests for suggestion operations.
+     */
     protected static class RequestParameter extends SearchRequestParams {
         private final String query;
 
@@ -173,6 +189,15 @@ public class SuggestApiManager extends ClassicJsonApiManager {
 
         private final String[] tags;
 
+        /**
+         * Constructs RequestParameter from HTTP request parameters.
+         *
+         * @param request the HTTP servlet request
+         * @param query the search query for suggestions
+         * @param tags the tags to filter suggestions
+         * @param fields the fields to search for suggestions
+         * @param num the maximum number of suggestions to return
+         */
         protected RequestParameter(final HttpServletRequest request, final String query, final String[] tags, final String[] fields,
                 final int num) {
             this.query = query;
@@ -182,6 +207,12 @@ public class SuggestApiManager extends ClassicJsonApiManager {
             this.request = request;
         }
 
+        /**
+         * Parses HTTP request parameters into a RequestParameter object.
+         *
+         * @param request the HTTP servlet request
+         * @return the parsed RequestParameter
+         */
         protected static RequestParameter parse(final HttpServletRequest request) {
             final String query = request.getParameter("query");
             final String fieldsStr = request.getParameter("fields");
@@ -216,10 +247,20 @@ public class SuggestApiManager extends ClassicJsonApiManager {
             return query;
         }
 
+        /**
+         * Gets the fields to search for suggestions.
+         *
+         * @return the suggest fields array
+         */
         protected String[] getSuggestFields() {
             return fields;
         }
 
+        /**
+         * Gets the maximum number of suggestions to return.
+         *
+         * @return the maximum number of suggestions
+         */
         protected int getNum() {
             return num;
         }
@@ -234,6 +275,11 @@ public class SuggestApiManager extends ClassicJsonApiManager {
             return Collections.emptyMap();
         }
 
+        /**
+         * Gets the tags used to filter suggestions.
+         *
+         * @return the tags array
+         */
         public String[] getTags() {
             return tags;
         }

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/ClassicJsonApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/ClassicJsonApiManagerTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2012-2025 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.fess.plugin.webapp.api.classic;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.codelibs.core.CoreLibConstants;
+import org.codelibs.fess.Constants;
+import org.codelibs.fess.api.WebApiManagerFactory;
+import org.codelibs.fess.mylasta.direction.FessConfig;
+import org.codelibs.fess.util.ComponentUtil;
+import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
+
+public class ClassicJsonApiManagerTest extends LastaFluteTestCase {
+
+    private WebApiManagerFactory webApiManagerFactory;
+
+    private TestClassicJsonApiManager manager;
+
+    @Override
+    protected String prepareConfigFile() {
+        return "test_app.xml";
+    }
+
+    @Override
+    protected boolean isSuppressTestCaseTransaction() {
+        return true;
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getApiJsonResponseExceptionIncluded() {
+                return Constants.FALSE;
+            }
+        });
+        webApiManagerFactory = new WebApiManagerFactory();
+        ComponentUtil.register(webApiManagerFactory, "webApiManagerFactory");
+        manager = new TestClassicJsonApiManager();
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        ComponentUtil.setFessConfig(null);
+        super.tearDown();
+    }
+
+    public void test_escapeCallbackName_normal() {
+        String result = manager.testEscapeCallbackName("myCallback123");
+        assertEquals("/**/myCallback123", result);
+    }
+
+    public void test_escapeCallbackName_withSpecialChars() {
+        String result = manager.testEscapeCallbackName("my<script>alert('xss')</script>Callback");
+        assertEquals("/**/myscriptalertxssscriptCallback", result);
+    }
+
+    public void test_escapeCallbackName_allowedSpecialChars() {
+        String result = manager.testEscapeCallbackName("my$Callback_123.test");
+        assertEquals("/**/my$Callback_123.test", result);
+    }
+
+    public void test_escapeCallbackName_empty() {
+        String result = manager.testEscapeCallbackName("");
+        assertEquals("/**/", result);
+    }
+
+    public void test_escapeJson_null() {
+        String result = manager.testEscapeJson(null);
+        assertEquals("null", result);
+    }
+
+    public void test_escapeJson_string() {
+        String result = manager.testEscapeJson("test string");
+        assertEquals("\"test string\"", result);
+    }
+
+    public void test_escapeJson_stringWithQuotes() {
+        String result = manager.testEscapeJson("test \"quoted\" string");
+        assertEquals("\"test \\\"quoted\\\" string\"", result);
+    }
+
+    public void test_escapeJson_stringWithNewlines() {
+        String result = manager.testEscapeJson("test\nstring\r\nwith\nnewlines");
+        assertEquals("\"test\\nstring\\r\\nwith\\nnewlines\"", result);
+    }
+
+    public void test_escapeJson_integer() {
+        String result = manager.testEscapeJson(42);
+        assertEquals("42", result);
+    }
+
+    public void test_escapeJson_long() {
+        String result = manager.testEscapeJson(123456789L);
+        assertEquals("123456789", result);
+    }
+
+    public void test_escapeJson_float() {
+        String result = manager.testEscapeJson(3.14f);
+        assertEquals("3.14", result);
+    }
+
+    public void test_escapeJson_double() {
+        String result = manager.testEscapeJson(2.71828);
+        assertEquals("2.71828", result);
+    }
+
+    public void test_escapeJson_boolean_true() {
+        String result = manager.testEscapeJson(true);
+        assertEquals("true", result);
+    }
+
+    public void test_escapeJson_boolean_false() {
+        String result = manager.testEscapeJson(false);
+        assertEquals("false", result);
+    }
+
+    public void test_escapeJson_date() {
+        Date date = new Date(1642780800000L); // 2022-01-21T12:00:00.000Z
+        String result = manager.testEscapeJson(date);
+        SimpleDateFormat sdf = new SimpleDateFormat(CoreLibConstants.DATE_FORMAT_ISO_8601_EXTEND, Locale.ROOT);
+        String expectedDate = sdf.format(date);
+        assertEquals("\"" + expectedDate + "\"", result);
+    }
+
+    public void test_escapeJson_stringArray() {
+        String[] array = { "test1", "test2", "test3" };
+        String result = manager.testEscapeJson(array);
+        assertEquals("[\"test1\",\"test2\",\"test3\"]", result);
+    }
+
+    public void test_escapeJson_emptyStringArray() {
+        String[] array = {};
+        String result = manager.testEscapeJson(array);
+        assertEquals("[]", result);
+    }
+
+    public void test_escapeJson_list() {
+        List<String> list = Arrays.asList("item1", "item2", "item3");
+        String result = manager.testEscapeJson(list);
+        assertEquals("[\"item1\",\"item2\",\"item3\"]", result);
+    }
+
+    public void test_escapeJson_emptyList() {
+        List<String> list = Arrays.asList();
+        String result = manager.testEscapeJson(list);
+        assertEquals("[]", result);
+    }
+
+    public void test_escapeJson_map() {
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        String result = manager.testEscapeJson(map);
+        assertTrue(result.contains("\"key1\":\"value1\""));
+        assertTrue(result.contains("\"key2\":\"value2\""));
+        assertTrue(result.startsWith("{"));
+        assertTrue(result.endsWith("}"));
+    }
+
+    public void test_escapeJson_emptyMap() {
+        Map<String, String> map = new HashMap<>();
+        String result = manager.testEscapeJson(map);
+        assertEquals("{}", result);
+    }
+
+    public void test_escapeJson_nestedStructure() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("string", "value");
+        map.put("number", 42);
+        map.put("array", Arrays.asList("item1", "item2"));
+        String result = manager.testEscapeJson(map);
+        assertTrue(result.contains("\"string\":\"value\""));
+        assertTrue(result.contains("\"number\":42"));
+        assertTrue(result.contains("\"array\":[\"item1\",\"item2\"]"));
+    }
+
+    public void test_setMimeType() {
+        assertEquals("application/json", manager.getMimeType());
+        manager.setMimeType("application/xml");
+        assertEquals("application/xml", manager.getMimeType());
+    }
+
+    // Test implementation of abstract ClassicJsonApiManager for testing purposes
+    private static class TestClassicJsonApiManager extends ClassicJsonApiManager {
+        private String mimeType = "application/json";
+
+        @Override
+        public boolean matches(HttpServletRequest request) {
+            return true;
+        }
+
+        @Override
+        public void process(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            // Test implementation
+        }
+
+        @Override
+        protected void write(String text, String contentType, String encoding) {
+            // Test implementation
+        }
+
+        @Override
+        protected void writeHeaders(HttpServletResponse response) {
+            // Test implementation - no actual headers needed
+        }
+
+        // Expose protected methods for testing
+        public String testEscapeCallbackName(String callbackName) {
+            return escapeCallbackName(callbackName);
+        }
+
+        public String testEscapeJson(Object obj) {
+            return escapeJson(obj);
+        }
+
+        public String getMimeType() {
+            return mimeType;
+        }
+
+        @Override
+        public void setMimeType(String mimeType) {
+            this.mimeType = mimeType;
+        }
+    }
+}

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManagerTest.java
@@ -15,7 +15,14 @@
  */
 package org.codelibs.fess.plugin.webapp.api.classic;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.codelibs.fess.api.WebApiManagerFactory;
+import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
@@ -38,6 +45,21 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     public void setUp() throws Exception {
         ComponentUtil.setFessConfig(new FessConfig.SimpleImpl() {
             private static final long serialVersionUID = 1L;
+
+            @Override
+            public Integer getPagingSearchPageStartAsInteger() {
+                return 0;
+            }
+
+            @Override
+            public Integer getPagingSearchPageSizeAsInteger() {
+                return 20;
+            }
+
+            @Override
+            public Integer getPagingSearchPageMaxSizeAsInteger() {
+                return 100;
+            }
         });
         webApiManagerFactory = new WebApiManagerFactory();
         ComponentUtil.register(webApiManagerFactory, "webApiManagerFactory");
@@ -53,5 +75,481 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     public void test_pathPrefix() {
         JsonApiManager jsonApiManager = getComponent("jsonApiManager");
         assertEquals("/json", jsonApiManager.getPathPrefix());
+    }
+
+    public void test_JsonRequestParams_construction() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("q", "test query");
+        request.setParameter("num", "20");
+        request.setParameter("start", "10");
+
+        FessConfig fessConfig = ComponentUtil.getFessConfig();
+        JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
+
+        assertEquals("test query", params.getQuery());
+        assertEquals(20, params.getPageSize());
+        assertEquals(10, params.getStartPosition());
+    }
+
+    public void test_JsonRequestParams_defaultValues() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        FessConfig fessConfig = ComponentUtil.getFessConfig();
+        JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
+
+        assertNull(params.getQuery());
+        assertTrue(params.getPageSize() > 0);
+        assertTrue(params.getStartPosition() >= 0);
+    }
+
+    public void test_JsonRequestParams_invalidPageSize() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("num", "invalid");
+
+        FessConfig fessConfig = ComponentUtil.getFessConfig();
+        JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
+
+        assertTrue(params.getPageSize() > 0); // Should fall back to default
+    }
+
+    public void test_JsonRequestParams_extraQueries() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("ex_q", "extra1");
+        request.addParameter("ex_q", "extra2");
+
+        FessConfig fessConfig = ComponentUtil.getFessConfig();
+        JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
+
+        String[] extraQueries = params.getExtraQueries();
+        assertEquals(2, extraQueries.length);
+        assertEquals("extra1", extraQueries[0]);
+        assertEquals("extra2", extraQueries[1]);
+    }
+
+    public void test_JsonRequestParams_type() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        FessConfig fessConfig = ComponentUtil.getFessConfig();
+        JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
+
+        assertEquals(SearchRequestType.JSON, params.getType());
+    }
+
+    public void test_JsonRequestParams_locale() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        FessConfig fessConfig = ComponentUtil.getFessConfig();
+        JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
+
+        assertEquals(Locale.ROOT, params.getLocale());
+    }
+
+    public void test_detailedMessage_nullException() {
+        TestableJsonApiManager manager = new TestableJsonApiManager();
+        String result = manager.testDetailedMessage(null);
+        assertEquals("Unknown", result);
+    }
+
+    public void test_detailedMessage_simpleException() {
+        TestableJsonApiManager manager = new TestableJsonApiManager();
+        RuntimeException ex = new RuntimeException("Test error");
+        String result = manager.testDetailedMessage(ex);
+        assertEquals("RuntimeException[Test error]", result);
+    }
+
+    public void test_detailedMessage_exceptionWithoutMessage() {
+        TestableJsonApiManager manager = new TestableJsonApiManager();
+        RuntimeException ex = new RuntimeException();
+        String result = manager.testDetailedMessage(ex);
+        // The actual implementation includes [null] when message is null
+        assertEquals("RuntimeException[null]", result);
+    }
+
+    public void test_detailedMessage_nestedException() {
+        TestableJsonApiManager manager = new TestableJsonApiManager();
+        RuntimeException cause = new RuntimeException("Root cause");
+        IllegalArgumentException ex = new IllegalArgumentException("Wrapper exception", cause);
+        String result = manager.testDetailedMessage(ex);
+        assertTrue(result.contains("IllegalArgumentException[Wrapper exception]"));
+        assertTrue(result.contains("nested:"));
+        assertTrue(result.contains("RuntimeException[Root cause]"));
+    }
+
+    // Test helper class to expose protected methods
+    public static class TestableJsonApiManager extends JsonApiManager {
+        public String testDetailedMessage(Throwable t) {
+            return detailedMessage(t);
+        }
+    }
+
+    // Mock HttpServletRequest for testing
+    private static class MockHttpServletRequest implements HttpServletRequest {
+        private final Map<String, String[]> parameters = new HashMap<>();
+        private final Map<String, Object> attributes = new HashMap<>();
+
+        public void setParameter(String name, String value) {
+            parameters.put(name, new String[] { value });
+        }
+
+        public void addParameter(String name, String value) {
+            String[] existing = parameters.get(name);
+            if (existing == null) {
+                parameters.put(name, new String[] { value });
+            } else {
+                String[] newArray = new String[existing.length + 1];
+                System.arraycopy(existing, 0, newArray, 0, existing.length);
+                newArray[existing.length] = value;
+                parameters.put(name, newArray);
+            }
+        }
+
+        @Override
+        public String getParameter(String name) {
+            String[] values = parameters.get(name);
+            return values != null && values.length > 0 ? values[0] : null;
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return parameters.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return parameters;
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return attributes.get(name);
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+            attributes.put(name, value);
+        }
+
+        // Stub implementations for other required methods
+        @Override
+        public String getAuthType() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            return null;
+        }
+
+        @Override
+        public long getDateHeader(String name) {
+            return 0;
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getHeaders(String name) {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getHeaderNames() {
+            return null;
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            return 0;
+        }
+
+        @Override
+        public String getMethod() {
+            return null;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getContextPath() {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return null;
+        }
+
+        @Override
+        public String getServletPath() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpSession getSession(boolean create) {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpSession getSession() {
+            return null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(jakarta.servlet.http.HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(String username, String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<jakarta.servlet.http.Part> getParts() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.Part getPart(String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getAttributeNames() {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.ServletInputStream getInputStream() {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getParameterNames() {
+            return null;
+        }
+
+        @Override
+        public String getProtocol() {
+            return null;
+        }
+
+        @Override
+        public String getScheme() {
+            return null;
+        }
+
+        @Override
+        public String getServerName() {
+            return null;
+        }
+
+        @Override
+        public int getServerPort() {
+            return 0;
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return null;
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<java.util.Locale> getLocales() {
+            return null;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
+            return null;
+        }
+
+        // getRealPath is deprecated in newer servlet API versions
+        public String getRealPath(String path) {
+            return null;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return null;
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return null;
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 0;
+        }
+
+        @Override
+        public jakarta.servlet.ServletContext getServletContext() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext startAsync() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext startAsync(jakarta.servlet.ServletRequest servletRequest,
+                jakarta.servlet.ServletResponse servletResponse) {
+            return null;
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext getAsyncContext() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.DispatcherType getDispatcherType() {
+            return null;
+        }
+
+        // Note: Some methods from newer servlet versions may not be available
+        public String getRequestId() {
+            return null;
+        }
+
+        public String getProtocolRequestId() {
+            return null;
+        }
+
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
     }
 }

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManagerTest.java
@@ -26,6 +26,8 @@ import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequestImpl;
+import org.dbflute.utflute.mocklet.MockletServletContextImpl;
 
 public class JsonApiManagerTest extends LastaFluteTestCase {
 
@@ -78,7 +80,8 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_JsonRequestParams_construction() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
         request.setParameter("q", "test query");
         request.setParameter("num", "20");
         request.setParameter("start", "10");
@@ -92,7 +95,8 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_JsonRequestParams_defaultValues() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
         FessConfig fessConfig = ComponentUtil.getFessConfig();
         JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
 
@@ -102,7 +106,8 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_JsonRequestParams_invalidPageSize() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
         request.setParameter("num", "invalid");
 
         FessConfig fessConfig = ComponentUtil.getFessConfig();
@@ -112,7 +117,8 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_JsonRequestParams_extraQueries() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
         request.addParameter("ex_q", "extra1");
         request.addParameter("ex_q", "extra2");
 
@@ -126,7 +132,8 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_JsonRequestParams_type() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
         FessConfig fessConfig = ComponentUtil.getFessConfig();
         JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
 
@@ -134,7 +141,8 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_JsonRequestParams_locale() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
         FessConfig fessConfig = ComponentUtil.getFessConfig();
         JsonApiManager.JsonRequestParams params = new JsonApiManager.JsonRequestParams(request, fessConfig);
 
@@ -179,377 +187,4 @@ public class JsonApiManagerTest extends LastaFluteTestCase {
         }
     }
 
-    // Mock HttpServletRequest for testing
-    private static class MockHttpServletRequest implements HttpServletRequest {
-        private final Map<String, String[]> parameters = new HashMap<>();
-        private final Map<String, Object> attributes = new HashMap<>();
-
-        public void setParameter(String name, String value) {
-            parameters.put(name, new String[] { value });
-        }
-
-        public void addParameter(String name, String value) {
-            String[] existing = parameters.get(name);
-            if (existing == null) {
-                parameters.put(name, new String[] { value });
-            } else {
-                String[] newArray = new String[existing.length + 1];
-                System.arraycopy(existing, 0, newArray, 0, existing.length);
-                newArray[existing.length] = value;
-                parameters.put(name, newArray);
-            }
-        }
-
-        @Override
-        public String getParameter(String name) {
-            String[] values = parameters.get(name);
-            return values != null && values.length > 0 ? values[0] : null;
-        }
-
-        @Override
-        public String[] getParameterValues(String name) {
-            return parameters.get(name);
-        }
-
-        @Override
-        public Map<String, String[]> getParameterMap() {
-            return parameters;
-        }
-
-        @Override
-        public Object getAttribute(String name) {
-            return attributes.get(name);
-        }
-
-        @Override
-        public void setAttribute(String name, Object value) {
-            attributes.put(name, value);
-        }
-
-        // Stub implementations for other required methods
-        @Override
-        public String getAuthType() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.Cookie[] getCookies() {
-            return null;
-        }
-
-        @Override
-        public long getDateHeader(String name) {
-            return 0;
-        }
-
-        @Override
-        public String getHeader(String name) {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getHeaders(String name) {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getHeaderNames() {
-            return null;
-        }
-
-        @Override
-        public int getIntHeader(String name) {
-            return 0;
-        }
-
-        @Override
-        public String getMethod() {
-            return null;
-        }
-
-        @Override
-        public String getPathInfo() {
-            return null;
-        }
-
-        @Override
-        public String getPathTranslated() {
-            return null;
-        }
-
-        @Override
-        public String getContextPath() {
-            return null;
-        }
-
-        @Override
-        public String getQueryString() {
-            return null;
-        }
-
-        @Override
-        public String getRemoteUser() {
-            return null;
-        }
-
-        @Override
-        public boolean isUserInRole(String role) {
-            return false;
-        }
-
-        @Override
-        public java.security.Principal getUserPrincipal() {
-            return null;
-        }
-
-        @Override
-        public String getRequestedSessionId() {
-            return null;
-        }
-
-        @Override
-        public String getRequestURI() {
-            return null;
-        }
-
-        @Override
-        public StringBuffer getRequestURL() {
-            return null;
-        }
-
-        @Override
-        public String getServletPath() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.HttpSession getSession(boolean create) {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.HttpSession getSession() {
-            return null;
-        }
-
-        @Override
-        public String changeSessionId() {
-            return null;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdValid() {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromCookie() {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromURL() {
-            return false;
-        }
-
-        @Override
-        public boolean authenticate(jakarta.servlet.http.HttpServletResponse response) {
-            return false;
-        }
-
-        @Override
-        public void login(String username, String password) {
-        }
-
-        @Override
-        public void logout() {
-        }
-
-        @Override
-        public java.util.Collection<jakarta.servlet.http.Part> getParts() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.Part getPart(String name) {
-            return null;
-        }
-
-        @Override
-        public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getAttributeNames() {
-            return null;
-        }
-
-        @Override
-        public String getCharacterEncoding() {
-            return null;
-        }
-
-        @Override
-        public void setCharacterEncoding(String env) {
-        }
-
-        @Override
-        public int getContentLength() {
-            return 0;
-        }
-
-        @Override
-        public long getContentLengthLong() {
-            return 0;
-        }
-
-        @Override
-        public String getContentType() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.ServletInputStream getInputStream() {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getParameterNames() {
-            return null;
-        }
-
-        @Override
-        public String getProtocol() {
-            return null;
-        }
-
-        @Override
-        public String getScheme() {
-            return null;
-        }
-
-        @Override
-        public String getServerName() {
-            return null;
-        }
-
-        @Override
-        public int getServerPort() {
-            return 0;
-        }
-
-        @Override
-        public java.io.BufferedReader getReader() {
-            return null;
-        }
-
-        @Override
-        public String getRemoteAddr() {
-            return null;
-        }
-
-        @Override
-        public String getRemoteHost() {
-            return null;
-        }
-
-        @Override
-        public void removeAttribute(String name) {
-        }
-
-        @Override
-        public java.util.Locale getLocale() {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<java.util.Locale> getLocales() {
-            return null;
-        }
-
-        @Override
-        public boolean isSecure() {
-            return false;
-        }
-
-        @Override
-        public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
-            return null;
-        }
-
-        // getRealPath is deprecated in newer servlet API versions
-        public String getRealPath(String path) {
-            return null;
-        }
-
-        @Override
-        public int getRemotePort() {
-            return 0;
-        }
-
-        @Override
-        public String getLocalName() {
-            return null;
-        }
-
-        @Override
-        public String getLocalAddr() {
-            return null;
-        }
-
-        @Override
-        public int getLocalPort() {
-            return 0;
-        }
-
-        @Override
-        public jakarta.servlet.ServletContext getServletContext() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.AsyncContext startAsync() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.AsyncContext startAsync(jakarta.servlet.ServletRequest servletRequest,
-                jakarta.servlet.ServletResponse servletResponse) {
-            return null;
-        }
-
-        @Override
-        public boolean isAsyncStarted() {
-            return false;
-        }
-
-        @Override
-        public boolean isAsyncSupported() {
-            return false;
-        }
-
-        @Override
-        public jakarta.servlet.AsyncContext getAsyncContext() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.DispatcherType getDispatcherType() {
-            return null;
-        }
-
-        // Note: Some methods from newer servlet versions may not be available
-        public String getRequestId() {
-            return null;
-        }
-
-        public String getProtocolRequestId() {
-            return null;
-        }
-
-        public jakarta.servlet.ServletConnection getServletConnection() {
-            return null;
-        }
-    }
 }

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManagerTest.java
@@ -15,7 +15,15 @@
  */
 package org.codelibs.fess.plugin.webapp.api.classic;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.codelibs.fess.api.WebApiManagerFactory;
+import org.codelibs.fess.entity.HighlightInfo;
+import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
@@ -53,5 +61,500 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     public void test_pathPrefix() {
         SuggestApiManager suggestApiManager = getComponent("suggestApiManager");
         assertEquals("/suggest", suggestApiManager.getPathPrefix());
+    }
+
+    public void test_RequestParameter_parse_basicParams() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("query", "test query");
+        request.setParameter("fields", "title,content");
+        request.setParameter("num", "15");
+        request.setParameter("tags", "tag1,tag2");
+
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        assertEquals("test query", params.getQuery());
+        assertEquals(2, params.getSuggestFields().length);
+        assertEquals("title", params.getSuggestFields()[0]);
+        assertEquals("content", params.getSuggestFields()[1]);
+        assertEquals(15, params.getNum());
+        assertEquals(2, params.getTags().length);
+        assertEquals("tag1", params.getTags()[0]);
+        assertEquals("tag2", params.getTags()[1]);
+    }
+
+    public void test_RequestParameter_parse_defaultValues() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        assertNull(params.getQuery());
+        assertEquals(0, params.getSuggestFields().length);
+        assertEquals(10, params.getNum()); // Default value
+        assertEquals(0, params.getTags().length);
+    }
+
+    public void test_RequestParameter_parse_emptyFields() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("fields", "");
+
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        assertEquals(0, params.getSuggestFields().length);
+    }
+
+    public void test_RequestParameter_parse_invalidNum() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("num", "invalid");
+
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        assertEquals(10, params.getNum()); // Should fall back to default
+    }
+
+    public void test_RequestParameter_parse_numericStringNum() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("num", "25");
+
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        assertEquals(25, params.getNum());
+    }
+
+    public void test_RequestParameter_getFields() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        Map<String, String[]> fields = params.getFields();
+        assertTrue(fields.isEmpty());
+    }
+
+    public void test_RequestParameter_getConditions() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        Map<String, String[]> conditions = params.getConditions();
+        assertTrue(conditions.isEmpty());
+    }
+
+    public void test_RequestParameter_getLanguages() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("lang", "ja");
+        request.addParameter("lang", "en");
+
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        String[] languages = params.getLanguages();
+        assertEquals(2, languages.length);
+        assertEquals("ja", languages[0]);
+        assertEquals("en", languages[1]);
+    }
+
+    public void test_RequestParameter_getType() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        assertEquals(SearchRequestType.SUGGEST, params.getType());
+    }
+
+    // Note: getHighlightInfo test removed due to configuration dependency
+
+    public void test_RequestParameter_unsupportedOperations() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
+
+        try {
+            params.getGeoInfo();
+            fail("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected
+        }
+
+        try {
+            params.getFacetInfo();
+            fail("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected
+        }
+
+        try {
+            params.getSort();
+            fail("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // Expected
+        }
+    }
+
+    // Mock HttpServletRequest for testing
+    private static class MockHttpServletRequest implements HttpServletRequest {
+        private final Map<String, String[]> parameters = new HashMap<>();
+        private final Map<String, Object> attributes = new HashMap<>();
+
+        public void setParameter(String name, String value) {
+            parameters.put(name, new String[] { value });
+        }
+
+        public void addParameter(String name, String value) {
+            String[] existing = parameters.get(name);
+            if (existing == null) {
+                parameters.put(name, new String[] { value });
+            } else {
+                String[] newArray = new String[existing.length + 1];
+                System.arraycopy(existing, 0, newArray, 0, existing.length);
+                newArray[existing.length] = value;
+                parameters.put(name, newArray);
+            }
+        }
+
+        @Override
+        public String getParameter(String name) {
+            String[] values = parameters.get(name);
+            return values != null && values.length > 0 ? values[0] : null;
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return parameters.get(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return parameters;
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return attributes.get(name);
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+            attributes.put(name, value);
+        }
+
+        // Stub implementations for other required methods
+        @Override
+        public String getAuthType() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            return null;
+        }
+
+        @Override
+        public long getDateHeader(String name) {
+            return 0;
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getHeaders(String name) {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getHeaderNames() {
+            return null;
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            return 0;
+        }
+
+        @Override
+        public String getMethod() {
+            return null;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return null;
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return null;
+        }
+
+        @Override
+        public String getContextPath() {
+            return null;
+        }
+
+        @Override
+        public String getQueryString() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return null;
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            return false;
+        }
+
+        @Override
+        public java.security.Principal getUserPrincipal() {
+            return null;
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return null;
+        }
+
+        @Override
+        public String getRequestURI() {
+            return null;
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return null;
+        }
+
+        @Override
+        public String getServletPath() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpSession getSession(boolean create) {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpSession getSession() {
+            return null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return null;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return false;
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return false;
+        }
+
+        @Override
+        public boolean authenticate(jakarta.servlet.http.HttpServletResponse response) {
+            return false;
+        }
+
+        @Override
+        public void login(String username, String password) {
+        }
+
+        @Override
+        public void logout() {
+        }
+
+        @Override
+        public java.util.Collection<jakarta.servlet.http.Part> getParts() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.http.Part getPart(String name) {
+            return null;
+        }
+
+        @Override
+        public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getAttributeNames() {
+            return null;
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return null;
+        }
+
+        @Override
+        public void setCharacterEncoding(String env) {
+        }
+
+        @Override
+        public int getContentLength() {
+            return 0;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return 0;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.ServletInputStream getInputStream() {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<String> getParameterNames() {
+            return null;
+        }
+
+        @Override
+        public String getProtocol() {
+            return null;
+        }
+
+        @Override
+        public String getScheme() {
+            return null;
+        }
+
+        @Override
+        public String getServerName() {
+            return null;
+        }
+
+        @Override
+        public int getServerPort() {
+            return 0;
+        }
+
+        @Override
+        public java.io.BufferedReader getReader() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return null;
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return null;
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+        }
+
+        @Override
+        public java.util.Locale getLocale() {
+            return null;
+        }
+
+        @Override
+        public java.util.Enumeration<java.util.Locale> getLocales() {
+            return null;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
+            return null;
+        }
+
+        // getRealPath is deprecated in newer servlet API versions
+        public String getRealPath(String path) {
+            return null;
+        }
+
+        @Override
+        public int getRemotePort() {
+            return 0;
+        }
+
+        @Override
+        public String getLocalName() {
+            return null;
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return null;
+        }
+
+        @Override
+        public int getLocalPort() {
+            return 0;
+        }
+
+        @Override
+        public jakarta.servlet.ServletContext getServletContext() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext startAsync() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext startAsync(jakarta.servlet.ServletRequest servletRequest,
+                jakarta.servlet.ServletResponse servletResponse) {
+            return null;
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return false;
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext getAsyncContext() {
+            return null;
+        }
+
+        @Override
+        public jakarta.servlet.DispatcherType getDispatcherType() {
+            return null;
+        }
+
+        // Note: Some methods from newer servlet versions may not be available
+        public String getRequestId() {
+            return null;
+        }
+
+        public String getProtocolRequestId() {
+            return null;
+        }
+
+        public jakarta.servlet.ServletConnection getServletConnection() {
+            return null;
+        }
     }
 }

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManagerTest.java
@@ -27,6 +27,8 @@ import org.codelibs.fess.entity.SearchRequestParams.SearchRequestType;
 import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
+import org.dbflute.utflute.mocklet.MockletHttpServletRequestImpl;
+import org.dbflute.utflute.mocklet.MockletServletContextImpl;
 
 public class SuggestApiManagerTest extends LastaFluteTestCase {
 
@@ -64,7 +66,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_parse_basicParams() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         request.setParameter("query", "test query");
         request.setParameter("fields", "title,content");
         request.setParameter("num", "15");
@@ -83,7 +86,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_parse_defaultValues() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
 
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
 
@@ -94,7 +98,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_parse_emptyFields() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         request.setParameter("fields", "");
 
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
@@ -103,7 +108,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_parse_invalidNum() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         request.setParameter("num", "invalid");
 
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
@@ -112,7 +118,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_parse_numericStringNum() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         request.setParameter("num", "25");
 
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
@@ -121,7 +128,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_getFields() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
 
         Map<String, String[]> fields = params.getFields();
@@ -129,7 +137,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_getConditions() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
 
         Map<String, String[]> conditions = params.getConditions();
@@ -137,7 +146,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_getLanguages() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         request.addParameter("lang", "ja");
         request.addParameter("lang", "en");
 
@@ -150,7 +160,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     }
 
     public void test_RequestParameter_getType() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
 
         assertEquals(SearchRequestType.SUGGEST, params.getType());
@@ -159,7 +170,8 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
     // Note: getHighlightInfo test removed due to configuration dependency
 
     public void test_RequestParameter_unsupportedOperations() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
+        MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
         SuggestApiManager.RequestParameter params = SuggestApiManager.RequestParameter.parse(request);
 
         try {
@@ -184,377 +196,4 @@ public class SuggestApiManagerTest extends LastaFluteTestCase {
         }
     }
 
-    // Mock HttpServletRequest for testing
-    private static class MockHttpServletRequest implements HttpServletRequest {
-        private final Map<String, String[]> parameters = new HashMap<>();
-        private final Map<String, Object> attributes = new HashMap<>();
-
-        public void setParameter(String name, String value) {
-            parameters.put(name, new String[] { value });
-        }
-
-        public void addParameter(String name, String value) {
-            String[] existing = parameters.get(name);
-            if (existing == null) {
-                parameters.put(name, new String[] { value });
-            } else {
-                String[] newArray = new String[existing.length + 1];
-                System.arraycopy(existing, 0, newArray, 0, existing.length);
-                newArray[existing.length] = value;
-                parameters.put(name, newArray);
-            }
-        }
-
-        @Override
-        public String getParameter(String name) {
-            String[] values = parameters.get(name);
-            return values != null && values.length > 0 ? values[0] : null;
-        }
-
-        @Override
-        public String[] getParameterValues(String name) {
-            return parameters.get(name);
-        }
-
-        @Override
-        public Map<String, String[]> getParameterMap() {
-            return parameters;
-        }
-
-        @Override
-        public Object getAttribute(String name) {
-            return attributes.get(name);
-        }
-
-        @Override
-        public void setAttribute(String name, Object value) {
-            attributes.put(name, value);
-        }
-
-        // Stub implementations for other required methods
-        @Override
-        public String getAuthType() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.Cookie[] getCookies() {
-            return null;
-        }
-
-        @Override
-        public long getDateHeader(String name) {
-            return 0;
-        }
-
-        @Override
-        public String getHeader(String name) {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getHeaders(String name) {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getHeaderNames() {
-            return null;
-        }
-
-        @Override
-        public int getIntHeader(String name) {
-            return 0;
-        }
-
-        @Override
-        public String getMethod() {
-            return null;
-        }
-
-        @Override
-        public String getPathInfo() {
-            return null;
-        }
-
-        @Override
-        public String getPathTranslated() {
-            return null;
-        }
-
-        @Override
-        public String getContextPath() {
-            return null;
-        }
-
-        @Override
-        public String getQueryString() {
-            return null;
-        }
-
-        @Override
-        public String getRemoteUser() {
-            return null;
-        }
-
-        @Override
-        public boolean isUserInRole(String role) {
-            return false;
-        }
-
-        @Override
-        public java.security.Principal getUserPrincipal() {
-            return null;
-        }
-
-        @Override
-        public String getRequestedSessionId() {
-            return null;
-        }
-
-        @Override
-        public String getRequestURI() {
-            return null;
-        }
-
-        @Override
-        public StringBuffer getRequestURL() {
-            return null;
-        }
-
-        @Override
-        public String getServletPath() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.HttpSession getSession(boolean create) {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.HttpSession getSession() {
-            return null;
-        }
-
-        @Override
-        public String changeSessionId() {
-            return null;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdValid() {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromCookie() {
-            return false;
-        }
-
-        @Override
-        public boolean isRequestedSessionIdFromURL() {
-            return false;
-        }
-
-        @Override
-        public boolean authenticate(jakarta.servlet.http.HttpServletResponse response) {
-            return false;
-        }
-
-        @Override
-        public void login(String username, String password) {
-        }
-
-        @Override
-        public void logout() {
-        }
-
-        @Override
-        public java.util.Collection<jakarta.servlet.http.Part> getParts() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.http.Part getPart(String name) {
-            return null;
-        }
-
-        @Override
-        public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getAttributeNames() {
-            return null;
-        }
-
-        @Override
-        public String getCharacterEncoding() {
-            return null;
-        }
-
-        @Override
-        public void setCharacterEncoding(String env) {
-        }
-
-        @Override
-        public int getContentLength() {
-            return 0;
-        }
-
-        @Override
-        public long getContentLengthLong() {
-            return 0;
-        }
-
-        @Override
-        public String getContentType() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.ServletInputStream getInputStream() {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<String> getParameterNames() {
-            return null;
-        }
-
-        @Override
-        public String getProtocol() {
-            return null;
-        }
-
-        @Override
-        public String getScheme() {
-            return null;
-        }
-
-        @Override
-        public String getServerName() {
-            return null;
-        }
-
-        @Override
-        public int getServerPort() {
-            return 0;
-        }
-
-        @Override
-        public java.io.BufferedReader getReader() {
-            return null;
-        }
-
-        @Override
-        public String getRemoteAddr() {
-            return null;
-        }
-
-        @Override
-        public String getRemoteHost() {
-            return null;
-        }
-
-        @Override
-        public void removeAttribute(String name) {
-        }
-
-        @Override
-        public java.util.Locale getLocale() {
-            return null;
-        }
-
-        @Override
-        public java.util.Enumeration<java.util.Locale> getLocales() {
-            return null;
-        }
-
-        @Override
-        public boolean isSecure() {
-            return false;
-        }
-
-        @Override
-        public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
-            return null;
-        }
-
-        // getRealPath is deprecated in newer servlet API versions
-        public String getRealPath(String path) {
-            return null;
-        }
-
-        @Override
-        public int getRemotePort() {
-            return 0;
-        }
-
-        @Override
-        public String getLocalName() {
-            return null;
-        }
-
-        @Override
-        public String getLocalAddr() {
-            return null;
-        }
-
-        @Override
-        public int getLocalPort() {
-            return 0;
-        }
-
-        @Override
-        public jakarta.servlet.ServletContext getServletContext() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.AsyncContext startAsync() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.AsyncContext startAsync(jakarta.servlet.ServletRequest servletRequest,
-                jakarta.servlet.ServletResponse servletResponse) {
-            return null;
-        }
-
-        @Override
-        public boolean isAsyncStarted() {
-            return false;
-        }
-
-        @Override
-        public boolean isAsyncSupported() {
-            return false;
-        }
-
-        @Override
-        public jakarta.servlet.AsyncContext getAsyncContext() {
-            return null;
-        }
-
-        @Override
-        public jakarta.servlet.DispatcherType getDispatcherType() {
-            return null;
-        }
-
-        // Note: Some methods from newer servlet versions may not be available
-        public String getRequestId() {
-            return null;
-        }
-
-        public String getProtocolRequestId() {
-            return null;
-        }
-
-        public jakarta.servlet.ServletConnection getServletConnection() {
-            return null;
-        }
-    }
 }


### PR DESCRIPTION
This update introduces comprehensive JavaDoc comments to the following classes in the classic JSON-based search API plugin:

- ClassicJsonApiManager
- JsonApiManager
- SuggestApiManager
- Corresponding test classes (JsonApiManagerTest, SuggestApiManagerTest)

These comments describe the purpose, parameters, and behavior of public and protected methods, constructors, and inner classes. This enhancement improves maintainability, code readability, and facilitates easier onboarding for new developers.