### PR TITLE
Update version to 15.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-webapp-classic-api</artifactId>
 	<packaging>jar</packaging>
 	<name>Classic Search API Plugin</name>
-	<version>15.0.1-SNAPSHOT</version>
+	<version>15.1.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-webapp-classic-api.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-webapp-classic-api.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.0.0</version>
+		<version>15.1.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
I updated the project version from 15.0.1-SNAPSHOT to 15.1.0-SNAPSHOT and aligned the parent POM version from 15.0.0 to 15.1.0 to follow the latest release cycle.

## Changes Made
- Updated project version in `pom.xml` from `15.0.1-SNAPSHOT` to `15.1.0-SNAPSHOT`
- Updated parent POM version from `15.0.0` to `15.1.0`

## Testing
This is a version update change that doesn't affect functionality. The build should continue to work as expected with the updated version numbers.

## Additional Notes
This change aligns the project with the latest Fess parent version 15.1.0 and prepares for the next development iteration.