### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,11 +42,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,19 +54,19 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
     - name: Checkout fess-parent
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: codelibs/fess-parent
         path: fess-parent
@@ -78,7 +78,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -92,4 +92,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Update outdated GitHub Actions in `.github/workflows/codeql-analysis.yml` to current major versions
- `actions/checkout` v2 -> v4, `actions/cache` v1 -> v4, `actions/setup-java` v2 -> v4
- `github/codeql-action/{init,autobuild,analyze}` v1 -> v3

## Test plan
- [ ] CodeQL workflow runs successfully on this PR
- [ ] No deprecation warnings emitted by GitHub Actions
- [ ] Maven cache and JDK 17 setup steps continue to work