### PR TITLE
fix(test): add missing JUnit 5 annotations so dormant tests run

### DIFF
--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/ClassicJsonApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/ClassicJsonApiManagerTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.plugin.webapp.api.classic;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
@@ -76,76 +77,91 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_escapeCallbackName_normal() {
         String result = manager.testEscapeCallbackName("myCallback123");
         assertEquals("/**/myCallback123", result);
     }
 
+    @Test
     public void test_escapeCallbackName_withSpecialChars() {
         String result = manager.testEscapeCallbackName("my<script>alert('xss')</script>Callback");
         assertEquals("/**/myscriptalertxssscriptCallback", result);
     }
 
+    @Test
     public void test_escapeCallbackName_allowedSpecialChars() {
         String result = manager.testEscapeCallbackName("my$Callback_123.test");
         assertEquals("/**/my$Callback_123.test", result);
     }
 
+    @Test
     public void test_escapeCallbackName_empty() {
         String result = manager.testEscapeCallbackName("");
         assertEquals("/**/", result);
     }
 
+    @Test
     public void test_escapeJson_null() {
         String result = manager.testEscapeJson(null);
         assertEquals("null", result);
     }
 
+    @Test
     public void test_escapeJson_string() {
         String result = manager.testEscapeJson("test string");
         assertEquals("\"test string\"", result);
     }
 
+    @Test
     public void test_escapeJson_stringWithQuotes() {
         String result = manager.testEscapeJson("test \"quoted\" string");
         assertEquals("\"test \\\"quoted\\\" string\"", result);
     }
 
+    @Test
     public void test_escapeJson_stringWithNewlines() {
         String result = manager.testEscapeJson("test\nstring\r\nwith\nnewlines");
         assertEquals("\"test\\nstring\\r\\nwith\\nnewlines\"", result);
     }
 
+    @Test
     public void test_escapeJson_integer() {
         String result = manager.testEscapeJson(42);
         assertEquals("42", result);
     }
 
+    @Test
     public void test_escapeJson_long() {
         String result = manager.testEscapeJson(123456789L);
         assertEquals("123456789", result);
     }
 
+    @Test
     public void test_escapeJson_float() {
         String result = manager.testEscapeJson(3.14f);
         assertEquals("3.14", result);
     }
 
+    @Test
     public void test_escapeJson_double() {
         String result = manager.testEscapeJson(2.71828);
         assertEquals("2.71828", result);
     }
 
+    @Test
     public void test_escapeJson_boolean_true() {
         String result = manager.testEscapeJson(true);
         assertEquals("true", result);
     }
 
+    @Test
     public void test_escapeJson_boolean_false() {
         String result = manager.testEscapeJson(false);
         assertEquals("false", result);
     }
 
+    @Test
     public void test_escapeJson_date() {
         Date date = new Date(1642780800000L); // 2022-01-21T12:00:00.000Z
         String result = manager.testEscapeJson(date);
@@ -154,30 +170,35 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("\"" + expectedDate + "\"", result);
     }
 
+    @Test
     public void test_escapeJson_stringArray() {
         String[] array = { "test1", "test2", "test3" };
         String result = manager.testEscapeJson(array);
         assertEquals("[\"test1\",\"test2\",\"test3\"]", result);
     }
 
+    @Test
     public void test_escapeJson_emptyStringArray() {
         String[] array = {};
         String result = manager.testEscapeJson(array);
         assertEquals("[]", result);
     }
 
+    @Test
     public void test_escapeJson_list() {
         List<String> list = Arrays.asList("item1", "item2", "item3");
         String result = manager.testEscapeJson(list);
         assertEquals("[\"item1\",\"item2\",\"item3\"]", result);
     }
 
+    @Test
     public void test_escapeJson_emptyList() {
         List<String> list = Arrays.asList();
         String result = manager.testEscapeJson(list);
         assertEquals("[]", result);
     }
 
+    @Test
     public void test_escapeJson_map() {
         Map<String, String> map = new HashMap<>();
         map.put("key1", "value1");
@@ -189,12 +210,14 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.endsWith("}"));
     }
 
+    @Test
     public void test_escapeJson_emptyMap() {
         Map<String, String> map = new HashMap<>();
         String result = manager.testEscapeJson(map);
         assertEquals("{}", result);
     }
 
+    @Test
     public void test_escapeJson_nestedStructure() {
         Map<String, Object> map = new HashMap<>();
         map.put("string", "value");
@@ -206,18 +229,21 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.contains("\"array\":[\"item1\",\"item2\"]"));
     }
 
+    @Test
     public void test_setMimeType() {
         assertEquals("application/json", manager.getMimeType());
         manager.setMimeType("application/xml");
         assertEquals("application/xml", manager.getMimeType());
     }
 
+    @Test
     public void test_escapeJson_listWithMixedTypes() {
         List<Object> list = Arrays.asList("text", 42, true, null);
         String result = manager.testEscapeJson(list);
         assertEquals("[\"text\",42,true,null]", result);
     }
 
+    @Test
     public void test_escapeJson_mapWithNullValue() {
         Map<String, String> map = new HashMap<>();
         map.put("key1", "value1");
@@ -227,16 +253,19 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.contains("\"key2\":null"));
     }
 
+    @Test
     public void test_escapeJson_stringWithBackslash() {
         String result = manager.testEscapeJson("test\\path\\file");
         assertEquals("\"test\\\\path\\\\file\"", result);
     }
 
+    @Test
     public void test_escapeJson_stringWithTab() {
         String result = manager.testEscapeJson("test\ttab");
         assertEquals("\"test\\ttab\"", result);
     }
 
+    @Test
     public void test_escapeJson_mixedIntegerTypes() {
         List<Object> list = Arrays.asList(Integer.valueOf(42), Long.valueOf(123456789L), Float.valueOf(3.14f), Double.valueOf(2.71828));
         String result = manager.testEscapeJson(list);
@@ -246,6 +275,7 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.contains("2.71828"));
     }
 
+    @Test
     public void test_escapeJson_complexNestedStructure() {
         Map<String, Object> inner = new HashMap<>();
         inner.put("nested_string", "value");
@@ -262,6 +292,7 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.contains("\"simple_array\":[1,2,3]"));
     }
 
+    @Test
     public void test_escapeJson_stringWithUnicodeCharacters() {
         String result = manager.testEscapeJson("テスト文字列");
         // StringEscapeUtils may escape Unicode characters
@@ -270,11 +301,13 @@ public class ClassicJsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.length() > 2); // Has content between quotes
     }
 
+    @Test
     public void test_escapeCallbackName_withParentheses() {
         String result = manager.testEscapeCallbackName("callback()");
         assertEquals("/**/callback", result);
     }
 
+    @Test
     public void test_escapeCallbackName_withBrackets() {
         String result = manager.testEscapeCallbackName("callback[0]");
         assertEquals("/**/callback0", result);

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/JsonApiManagerTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.plugin.webapp.api.classic;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.util.HashMap;
@@ -76,11 +77,13 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_pathPrefix() {
         JsonApiManager jsonApiManager = getComponent("jsonApiManager");
         assertEquals("/json", jsonApiManager.getPathPrefix());
     }
 
+    @Test
     public void test_JsonRequestParams_construction() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -96,6 +99,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(10, params.getStartPosition());
     }
 
+    @Test
     public void test_JsonRequestParams_defaultValues() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -107,6 +111,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(params.getStartPosition() >= 0);
     }
 
+    @Test
     public void test_JsonRequestParams_invalidPageSize() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -118,6 +123,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(params.getPageSize() > 0); // Should fall back to default
     }
 
+    @Test
     public void test_JsonRequestParams_extraQueries() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -133,6 +139,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("extra2", extraQueries[1]);
     }
 
+    @Test
     public void test_JsonRequestParams_type() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -142,6 +149,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(SearchRequestType.JSON, params.getType());
     }
 
+    @Test
     public void test_JsonRequestParams_locale() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -151,12 +159,14 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(Locale.ROOT, params.getLocale());
     }
 
+    @Test
     public void test_detailedMessage_nullException() {
         TestableJsonApiManager manager = new TestableJsonApiManager();
         String result = manager.testDetailedMessage(null);
         assertEquals("Unknown", result);
     }
 
+    @Test
     public void test_detailedMessage_simpleException() {
         TestableJsonApiManager manager = new TestableJsonApiManager();
         RuntimeException ex = new RuntimeException("Test error");
@@ -164,6 +174,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("RuntimeException[Test error]", result);
     }
 
+    @Test
     public void test_detailedMessage_exceptionWithoutMessage() {
         TestableJsonApiManager manager = new TestableJsonApiManager();
         RuntimeException ex = new RuntimeException();
@@ -172,6 +183,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("RuntimeException[null]", result);
     }
 
+    @Test
     public void test_detailedMessage_nestedException() {
         TestableJsonApiManager manager = new TestableJsonApiManager();
         RuntimeException cause = new RuntimeException("Root cause");
@@ -182,6 +194,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertTrue(result.contains("RuntimeException[Root cause]"));
     }
 
+    @Test
     public void test_JsonRequestParams_fields() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -202,6 +215,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("value2", fields.get("content")[1]);
     }
 
+    @Test
     public void test_JsonRequestParams_conditions() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -218,6 +232,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("pdf", conditions.get("filetype")[0]);
     }
 
+    @Test
     public void test_JsonRequestParams_languages() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -233,6 +248,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("en", languages[1]);
     }
 
+    @Test
     public void test_JsonRequestParams_sort() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -244,6 +260,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("score.desc", params.getSort());
     }
 
+    @Test
     public void test_JsonRequestParams_similarDocHash() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -255,6 +272,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("abc123", params.getSimilarDocHash());
     }
 
+    @Test
     public void test_JsonRequestParams_offset() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -266,6 +284,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(5, params.getOffset());
     }
 
+    @Test
     public void test_JsonRequestParams_offset_default() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -276,6 +295,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(0, params.getOffset());
     }
 
+    @Test
     public void test_JsonRequestParams_offset_invalid() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -287,6 +307,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(0, params.getOffset());
     }
 
+    @Test
     public void test_JsonRequestParams_trackTotalHits() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -298,6 +319,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("10000", params.getTrackTotalHits());
     }
 
+    @Test
     public void test_JsonRequestParams_getAttribute() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -309,6 +331,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals("test_value", params.getAttribute("test_attribute"));
     }
 
+    @Test
     public void test_JsonRequestParams_pageSize_exceedsMax() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -320,6 +343,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(100, params.getPageSize()); // Should be capped at max
     }
 
+    @Test
     public void test_JsonRequestParams_pageSize_zero() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -331,6 +355,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(100, params.getPageSize()); // Should fall back to max
     }
 
+    @Test
     public void test_JsonRequestParams_pageSize_negative() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");
@@ -342,6 +367,7 @@ public class JsonApiManagerTest extends UnitWebappTestCase {
         assertEquals(100, params.getPageSize()); // Should fall back to max
     }
 
+    @Test
     public void test_JsonRequestParams_startPosition_invalid() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/json");

--- a/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManagerTest.java
+++ b/src/test/java/org/codelibs/fess/plugin/webapp/api/classic/SuggestApiManagerTest.java
@@ -15,6 +15,7 @@
  */
 package org.codelibs.fess.plugin.webapp.api.classic;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.util.Collections;
@@ -62,11 +63,13 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_pathPrefix() {
         SuggestApiManager suggestApiManager = getComponent("suggestApiManager");
         assertEquals("/suggest", suggestApiManager.getPathPrefix());
     }
 
+    @Test
     public void test_RequestParameter_parse_basicParams() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -87,6 +90,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals("tag2", params.getTags()[1]);
     }
 
+    @Test
     public void test_RequestParameter_parse_defaultValues() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -99,6 +103,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(0, params.getTags().length);
     }
 
+    @Test
     public void test_RequestParameter_parse_emptyFields() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -109,6 +114,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(0, params.getSuggestFields().length);
     }
 
+    @Test
     public void test_RequestParameter_parse_invalidNum() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -119,6 +125,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(10, params.getNum()); // Should fall back to default
     }
 
+    @Test
     public void test_RequestParameter_parse_numericStringNum() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -129,6 +136,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(25, params.getNum());
     }
 
+    @Test
     public void test_RequestParameter_getFields() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -138,6 +146,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertTrue(fields.isEmpty());
     }
 
+    @Test
     public void test_RequestParameter_getConditions() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -147,6 +156,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertTrue(conditions.isEmpty());
     }
 
+    @Test
     public void test_RequestParameter_getLanguages() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -161,6 +171,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals("en", languages[1]);
     }
 
+    @Test
     public void test_RequestParameter_getType() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -171,6 +182,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
 
     // Note: getHighlightInfo test removed due to configuration dependency
 
+    @Test
     public void test_RequestParameter_unsupportedOperations() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -247,6 +259,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         }
     }
 
+    @Test
     public void test_RequestParameter_parse_singleField() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -258,6 +271,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals("title", params.getSuggestFields()[0]);
     }
 
+    @Test
     public void test_RequestParameter_parse_singleTag() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -269,6 +283,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals("tag1", params.getTags()[0]);
     }
 
+    @Test
     public void test_RequestParameter_parse_zeroNum() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -279,6 +294,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(0, params.getNum());
     }
 
+    @Test
     public void test_RequestParameter_parse_largeNum() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -289,6 +305,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(1000, params.getNum());
     }
 
+    @Test
     public void test_RequestParameter_parse_multipleFieldsWithSpaces() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -300,6 +317,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertTrue(params.getSuggestFields().length >= 3);
     }
 
+    @Test
     public void test_RequestParameter_parse_emptyTags() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");
@@ -310,6 +328,7 @@ public class SuggestApiManagerTest extends UnitWebappTestCase {
         assertEquals(0, params.getTags().length);
     }
 
+    @Test
     public void test_RequestParameter_parse_queryNull() {
         MockletServletContextImpl servletContext = new MockletServletContextImpl("/fess");
         MockletHttpServletRequestImpl request = new MockletHttpServletRequestImpl(servletContext, "/suggest");


### PR DESCRIPTION
## Problem

The test base class `UnitWebappTestCase` extends utflute's `LastaFluteTestCase`, which has migrated to JUnit 5 (Jupiter). Under JUnit 5, Surefire only executes methods annotated with `@Test`. The `test_*` methods in these test classes carried no `@Test` annotation, so Surefire silently skipped them -- the entire test classes never ran (0 tests executed).

## Fix

Added `@Test` (and `import org.junit.jupiter.api.Test;`) to every no-argument `void test_*` method:

| File | @Test added |
| --- | --- |
| `ClassicJsonApiManagerTest` | 32 |
| `SuggestApiManagerTest` | 18 |
| `JsonApiManagerTest` | 25 |
| **Total** | **75** |

Helper methods on the inner test-support classes (`testEscapeCallbackName`, `testEscapeJson`, `testDetailedMessage`, etc.) take arguments and are not test methods, so they were intentionally left unannotated.

This is the only change -- 75 `@Test` annotations and 3 imports. No other test infrastructure was modified.

## Verification

```
Tests run: 75, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

All 75 previously-dormant tests now execute and pass.